### PR TITLE
[ENHANCEMENT] - added UnifiedSession table to admin panel

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -1,8 +1,35 @@
 from django.contrib import admin
-from .models import URLRequestTable
+from .models import URLRequestTable, UnifiedSession
 from django_celery_results.models import TaskResult
 
 # Register your models here.
+
+class UnifiedSessionAdmin(admin.ModelAdmin):
+    list_display = ['session_id_short', 'user_ip', 'total_requests_display', 'video_requests', 'playlist_requests', 'topic_requests', 'created_at', 'last_request_at']
+    list_filter = ['created_at', 'last_request_at', 'user_ip']
+    search_fields = ['user_ip', 'session_id']
+    readonly_fields = ['session_id', 'created_at', 'last_request_at', 'total_requests_display']
+    ordering = ['-last_request_at']
+    
+    fieldsets = (
+        ('Session Info', {
+            'fields': ('session_id', 'user_ip', 'user_account')
+        }),
+        ('Request Counters', {
+            'fields': ('video_requests', 'playlist_requests', 'topic_requests', 'total_requests_display')
+        }),
+        ('Timestamps', {
+            'fields': ('created_at', 'last_request_at')
+        }),
+    )
+    
+    def session_id_short(self, obj):
+        return str(obj.session_id)[:8]
+    session_id_short.short_description = 'Session ID'
+    
+    def total_requests_display(self, obj):
+        return f"{obj.total_requests}/3"
+    total_requests_display.short_description = 'Total Requests'
 
 class URLRequestTableAdmin(admin.ModelAdmin):
     list_display = ['request_id_short', 'url', 'ip_address', 'status', 'failure_reason', 'created_at']
@@ -30,3 +57,4 @@ class CustomTaskResultAdmin(admin.ModelAdmin):
 admin.site.unregister(TaskResult)
 admin.site.register(TaskResult, CustomTaskResultAdmin)
 admin.site.register(URLRequestTable, URLRequestTableAdmin)
+admin.site.register(UnifiedSession, UnifiedSessionAdmin)

--- a/api/admin.py
+++ b/api/admin.py
@@ -6,9 +6,10 @@ from django_celery_results.models import TaskResult
 
 class UnifiedSessionAdmin(admin.ModelAdmin):
     list_display = ['session_id_short', 'user_ip', 'total_requests_display', 'video_requests', 'playlist_requests', 'topic_requests', 'created_at', 'last_request_at']
-    list_filter = ['created_at', 'last_request_at', 'user_ip']
-    search_fields = ['user_ip', 'session_id']
-    readonly_fields = ['session_id', 'created_at', 'last_request_at', 'total_requests_display']
+    list_filter = ['created_at', 'last_request_at']
+    search_fields = ['user_ip', '^session_id']
+    readonly_fields = ['session_id', 'created_at', 'last_request_at', 'total_requests_display',
+                       'video_requests', 'playlist_requests', 'topic_requests']
     ordering = ['-last_request_at']
     
     fieldsets = (


### PR DESCRIPTION
Missed adding UnifiedSession table to admin panel in the previos PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin dashboard view for unified sessions: sortable session list with filters by date, search by IP/session, read-only timestamps, concise session IDs, and visible counters for video/playlist/topic requests and totals.
  * Enhanced the request log admin: search by URL and IP, read-only request identifiers and timestamps, and shortened request IDs for easier scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->